### PR TITLE
Fix next config, add padding to bottom of twitter container

### DIFF
--- a/components/Dashboard/Dashboard.scss
+++ b/components/Dashboard/Dashboard.scss
@@ -65,6 +65,13 @@
   margin-bottom: 0.75em;
 }
 
+.twitterInnerContainer {
+  border-radius: 1em;
+  background-color: #ffffff;
+  height: 40.5em;
+  overflow: hidden;
+}
+
 .timeRow {
   margin-top: 2em;
 }

--- a/components/Dashboard/index.js
+++ b/components/Dashboard/index.js
@@ -117,15 +117,17 @@ export default class Dashboard extends Component {
           </Col>
           <Col className={styles.twitterContainer} lg={3}>
             <h2 className={styles.twitterTitle}>Twitter</h2>
-            <Timeline
-              dataSource={{ sourceType: 'profile', screenName: 'uiuc_rp' }}
-              options={{
-                chrome: 'noborders nofooter noheader noscrollbar',
-                tweetLimit: 4,
-                ariaPolite: 'rude',
-                username: 'uiuc_rp'
-              }}
-            />
+            <div className={styles.twitterInnerContainer}>
+              <Timeline
+                dataSource={{ sourceType: 'profile', screenName: 'uiuc_rp' }}
+                options={{
+                  chrome: 'noborders nofooter noheader noscrollbar',
+                  tweetLimit: 4,
+                  ariaPolite: 'rude',
+                  username: 'uiuc_rp'
+                }}
+              />
+            </div>
           </Col>
           <Col>
             <Row className={`justify-content-center ${styles.logoRow}`}>

--- a/next.config.js
+++ b/next.config.js
@@ -25,7 +25,8 @@ module.exports = (phase, { defaultConfig }) => {
         '/register': { page: '/register' },
         '/resume': { page: '/resume' },
         '/volunteer': { page: '/volunteer' },
-        '/challenge': { page: '/challenge' }
+        '/challenge': { page: '/challenge' },
+        '/dashboard': { page: '/dashboard' }
       };
     }
   });


### PR DESCRIPTION
This PR edits the next config so the dashboard shows in prod, and also makes it so there is space between the bottom of the twitter widget and the bottom of the container it is held in.
![image](https://user-images.githubusercontent.com/32113753/65068191-c312a900-d94d-11e9-8bbe-e67a1dc838dd.png)
